### PR TITLE
Add no_auth channel pathway

### DIFF
--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -107,6 +107,17 @@ describe("Channel", () => {
     });
   });
 
+  test("joinChannel/2 no_auth", async () => {
+    await lasagna.initChannel("unit-test:no_auth:hola");
+    await lasagna.joinChannel("unit-test:no_auth:hola");
+
+    expect(mockChannelJoin).toHaveBeenCalledTimes(1);
+    expect(lasagna.CHANNELS["unit-test:no_auth:hola"].channel).toBeDefined();
+    expect(
+      lasagna.CHANNELS["unit-test:no_auth:hola"].params.jwt
+    ).toBeUndefined();
+  });
+
   test("joinChannel/2 with unexpected ChannelMap corruption", async () => {
     delete lasagna.CHANNELS["unit-test:thing1"];
     expect(await lasagna.joinChannel("unit-test:thing1")).toBe(false);


### PR DESCRIPTION
Lasagna, at the time of this commit anyway, offers two channel types: authed (`push`) and unauthed (`push:no_auth`).

This change allows the client to take advantage of the faster no auth payways when appropriate.