### PR TITLE
Add channel join defensive logic

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -99,7 +99,7 @@ export default class Lasagna {
    */
 
   async initChannel(topic: Topic, params: Params = {}, callbacks?: ChannelCbs) {
-    if (!this.#socket) {
+    if (typeof topic !== "string" || topic === "" || !this.#socket) {
       return false;
     }
 
@@ -133,7 +133,7 @@ export default class Lasagna {
   }
 
   async joinChannel(topic: Topic, callback: Callback = () => undefined) {
-    if (!this.CHANNELS[topic]) {
+    if (typeof topic !== "string" || topic === "" || !this.CHANNELS[topic]) {
       return false;
     }
 


### PR DESCRIPTION
We don't want to TypeError if users feed something strange (eg: a boolean) in as a `topic`.