### PR TITLE
Add channel refresh JWT string check

### DIFF
--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -82,6 +82,15 @@ describe("Channel", () => {
     expect(await burntLasagna.initChannel("unit-test:thing5")).toBe(false);
   });
 
+  test("initChannel/2 with non-string JWT fetch response", async () => {
+    // @ts-ignore we want this type mismatch for the test scenario
+    const lasagna2 = new Lasagna(() => Promise.resolve({ notajwt: 1 }), url);
+    await lasagna2.initSocket({ jwt: jwtExplicitPassed });
+    await lasagna2.initChannel("unit-test:thing7");
+    lasagna2.connect();
+    expect(await lasagna2.joinChannel("unit-test:thing7")).toBe(false);
+  });
+
   test("joinChannel/2", () => {
     lasagna.joinChannel("unit-test:thing1");
     expect(mockChannelJoin).toHaveBeenCalledTimes(1);
@@ -121,6 +130,16 @@ describe("Channel", () => {
   test("joinChannel/2 with unexpected ChannelMap corruption", async () => {
     delete lasagna.CHANNELS["unit-test:thing1"];
     expect(await lasagna.joinChannel("unit-test:thing1")).toBe(false);
+  });
+
+  test("joinChannel/2 with non-string JWT fetch response", async () => {
+    // @ts-ignore we want this type mismatch for the test scenario
+    const lasagna2 = new Lasagna(() => Promise.resolve({ notajwt: 1 }), url);
+    await lasagna2.initSocket({ jwt: jwtExplicitPassed });
+    await lasagna2.initChannel("unit-test:thing8", { jwt: jwtExplicitPassed });
+    lasagna2.connect();
+    delete lasagna2.CHANNELS["unit-test:thing8"].params.jwt;
+    expect(await lasagna2.joinChannel("unit-test:thing8")).toBe(false);
   });
 
   test("channelPush/3", () => {

--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -17,24 +17,26 @@ import Lasagna from "../lib/lasagna";
  */
 describe("Socket", () => {
   const url = "http://unit-test.local";
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTg3NTY2MTM4LCJleHAiOjIyMTg1NTAzNjg4OH0.A1fxARHsTBcjJez9MEDrqm8xC3ypasfAGBTl1A64sD0";
+  const anotherJwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTg3NTY2MTM4LCJleHAiOjE5MDI5ODEyNjA1OH0.prqRY4pl4Q0C3R73ZKCAx5KwAEYc-DMDsKDvLHV-sx4";
   let lasagna: Lasagna;
 
   beforeEach(() => {
-    lasagna = new Lasagna(() => Promise.resolve("faux-jwt-resp"), url);
+    lasagna = new Lasagna(() => Promise.resolve(jwt), url);
     jest.clearAllMocks();
   });
 
   test("initSocket/1 without jwt param", async () => {
     await lasagna.initSocket({ user_id: "dmte", email: "bob@example.com" });
     lasagna.connect();
-    expect(MockPhoenix.Socket).toHaveBeenCalledWith(url, {
-      params: { jwt: "faux-jwt-resp" },
-    });
+    expect(MockPhoenix.Socket).toHaveBeenCalledWith(url, { params: { jwt } });
     expect(mockSocketConnect).toHaveBeenCalledTimes(1);
   });
 
   test("initSocket/1 with jwt param", async () => {
-    const params = { jwt: "test" };
+    const params = { jwt: anotherJwt };
     await lasagna.initSocket(params);
     lasagna.connect();
     expect(MockPhoenix.Socket).toHaveBeenCalledWith(url, { params });
@@ -54,7 +56,7 @@ describe("Socket", () => {
   });
 
   test("initSocket/1 with jwt param and callbacks", async () => {
-    const params = { jwt: "test" };
+    const params = { jwt: anotherJwt };
     const callbacks = {
       onOpen: () => "yay!",
       onClose: () => "aww",
@@ -73,13 +75,13 @@ describe("Socket", () => {
   });
 
   test("isConnected/0", async () => {
-    await lasagna.initSocket({ jwt: "test" });
+    await lasagna.initSocket({ jwt: anotherJwt });
     expect(lasagna.isConnected()).toBe(false);
     expect(mockSocketIsConnected).toHaveBeenCalledTimes(1);
   });
 
   test("disconnect/0", async () => {
-    await lasagna.initSocket({ jwt: "test" });
+    await lasagna.initSocket({ jwt: anotherJwt });
     lasagna.connect();
     lasagna.disconnect();
     expect(mockSocketDisconnect).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Proposed Changes

- Verify the result of a channel refresh is a string. We know it's an invalid JWT if it is not.

### How To Test

Unit tests.