### PR TITLE
Update no_auth prefix

### DIFF
--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -14,7 +14,7 @@ import Lasagna from "../lib/lasagna";
  * Test
  */
 describe("Channel", () => {
-  const url = "http://unit-test.local";
+  const url = "http://test.local";
   const jwtExpired =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0Ijo5MjQ3OTA2NTgsImV4cCI6OTI0NzkxNjU4fQ.iwZ26LyWfUjWK09Z0Z7bbkw6y8J2_hODsIgUU-HYh3k";
   const jwtExplicitPassed =
@@ -26,144 +26,155 @@ describe("Channel", () => {
   beforeEach(async () => {
     lasagna = new Lasagna(() => Promise.resolve(jwtRemoteFetched), url);
     await lasagna.initSocket({ remote: "stuff" });
-    await lasagna.initChannel("unit-test:thing1");
-    await lasagna.initChannel("unit-test:thing3", { jwt: jwtExplicitPassed });
+    await lasagna.initChannel("test:thing1");
+    await lasagna.initChannel("test:thing3", { jwt: jwtExplicitPassed });
     lasagna.connect();
-    lasagna.joinChannel("unit-test:thing3");
+    lasagna.joinChannel("test:thing3");
     jest.clearAllMocks();
   });
 
   test("initChannel/2 without jwt param", async () => {
-    await lasagna.initChannel("unit-test:thing2", { private: "thingy" });
+    await lasagna.initChannel("test:thing2", { private: "thingy" });
 
-    expect(lasagna.CHANNELS["unit-test:thing2"].channel).toBeDefined();
-    expect(lasagna.CHANNELS["unit-test:thing2"]).toMatchObject({
+    expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
+    expect(lasagna.CHANNELS["test:thing2"]).toMatchObject({
       params: { jwt: jwtRemoteFetched, private: "thingy" },
-      topic: "unit-test:thing2",
+      topic: "test:thing2",
       retries: 0,
     });
   });
 
   test("initChannel/2 with jwt param", async () => {
-    await lasagna.initChannel("unit-test:thing2", { jwt: jwtExplicitPassed });
+    await lasagna.initChannel("test:thing2", { jwt: jwtExplicitPassed });
 
-    expect(lasagna.CHANNELS["unit-test:thing2"].channel).toBeDefined();
-    expect(lasagna.CHANNELS["unit-test:thing2"]).toMatchObject({
+    expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
+    expect(lasagna.CHANNELS["test:thing2"]).toMatchObject({
       params: { jwt: jwtExplicitPassed },
-      topic: "unit-test:thing2",
+      topic: "test:thing2",
       retries: 0,
     });
   });
 
   test("initChannel/2 with expired jwt param", async () => {
-    await lasagna.initChannel("unit-test:thing2", { jwt: jwtExpired });
+    await lasagna.initChannel("test:thing2", { jwt: jwtExpired });
 
-    expect(lasagna.CHANNELS["unit-test:thing2"].channel).toBeDefined();
-    expect(lasagna.CHANNELS["unit-test:thing2"]).toMatchObject({
+    expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
+    expect(lasagna.CHANNELS["test:thing2"]).toMatchObject({
       params: { jwt: jwtRemoteFetched },
-      topic: "unit-test:thing2",
+      topic: "test:thing2",
       retries: 0,
     });
   });
 
   test("initChannel/2 with malformed jwt param", async () => {
-    await lasagna.initChannel("unit-test:thing2", { jwt: "blahblah" });
+    await lasagna.initChannel("test:thing2", { jwt: "blahblah" });
 
-    expect(lasagna.CHANNELS["unit-test:thing2"].channel).toBeDefined();
-    expect(lasagna.CHANNELS["unit-test:thing2"]).toMatchObject({
+    expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
+    expect(lasagna.CHANNELS["test:thing2"]).toMatchObject({
       params: { jwt: jwtRemoteFetched },
-      topic: "unit-test:thing2",
+      topic: "test:thing2",
       retries: 0,
     });
   });
 
   test("initChannel/2 with no socket", async () => {
     const burntLasagna = new Lasagna(() => Promise.resolve("whatever"), url);
-    expect(await burntLasagna.initChannel("unit-test:thing5")).toBe(false);
+    expect(await burntLasagna.initChannel("test:thing5")).toBe(false);
   });
 
   test("initChannel/2 with non-string JWT fetch response", async () => {
     // @ts-ignore we want this type mismatch for the test scenario
     const lasagna2 = new Lasagna(() => Promise.resolve({ notajwt: 1 }), url);
     await lasagna2.initSocket({ jwt: jwtExplicitPassed });
-    await lasagna2.initChannel("unit-test:thing7");
+    await lasagna2.initChannel("test:thing7");
     lasagna2.connect();
-    expect(await lasagna2.joinChannel("unit-test:thing7")).toBe(false);
+    expect(await lasagna2.joinChannel("test:thing7")).toBe(false);
   });
 
   test("joinChannel/2", () => {
-    lasagna.joinChannel("unit-test:thing1");
+    lasagna.joinChannel("test:thing1");
     expect(mockChannelJoin).toHaveBeenCalledTimes(1);
   });
 
   test("joinChannel/2 with callback", () => {
     const cb = jest.fn().mockImplementation(() => "howdy!");
-    lasagna.joinChannel("unit-test:thing1", cb);
+    lasagna.joinChannel("test:thing1", cb);
     expect(mockChannelJoin).toHaveBeenCalledTimes(1);
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
   test("joinChannel/2 with (artificially) forced channel refresh", async () => {
-    delete lasagna.CHANNELS["unit-test:thing1"].params.jwt;
-    await lasagna.joinChannel("unit-test:thing1");
+    delete lasagna.CHANNELS["test:thing1"].params.jwt;
+    await lasagna.joinChannel("test:thing1");
 
     expect(mockChannelJoin).toHaveBeenCalledTimes(1);
-    expect(lasagna.CHANNELS["unit-test:thing1"].channel).toBeDefined();
-    expect(lasagna.CHANNELS["unit-test:thing1"]).toMatchObject({
+    expect(lasagna.CHANNELS["test:thing1"].channel).toBeDefined();
+    expect(lasagna.CHANNELS["test:thing1"]).toMatchObject({
       params: { jwt: jwtRemoteFetched },
-      topic: "unit-test:thing1",
+      topic: "test:thing1",
       retries: 0,
     });
   });
 
   test("joinChannel/2 no_auth", async () => {
-    await lasagna.initChannel("unit-test:no_auth:hola");
-    await lasagna.joinChannel("unit-test:no_auth:hola");
+    await lasagna.initChannel("test-no_auth:hola");
+    await lasagna.joinChannel("test-no_auth:hola");
 
     expect(mockChannelJoin).toHaveBeenCalledTimes(1);
-    expect(lasagna.CHANNELS["unit-test:no_auth:hola"].channel).toBeDefined();
-    expect(
-      lasagna.CHANNELS["unit-test:no_auth:hola"].params.jwt
-    ).toBeUndefined();
+    expect(lasagna.CHANNELS["test-no_auth:hola"].channel).toBeDefined();
+    expect(lasagna.CHANNELS["test-no_auth:hola"].params.jwt).toBeUndefined();
   });
 
   test("joinChannel/2 with unexpected ChannelMap corruption", async () => {
-    delete lasagna.CHANNELS["unit-test:thing1"];
-    expect(await lasagna.joinChannel("unit-test:thing1")).toBe(false);
+    delete lasagna.CHANNELS["test:thing1"];
+    expect(await lasagna.joinChannel("test:thing1")).toBe(false);
   });
 
   test("joinChannel/2 with non-string JWT fetch response", async () => {
     // @ts-ignore we want this type mismatch for the test scenario
     const lasagna2 = new Lasagna(() => Promise.resolve({ notajwt: 1 }), url);
     await lasagna2.initSocket({ jwt: jwtExplicitPassed });
-    await lasagna2.initChannel("unit-test:thing8", { jwt: jwtExplicitPassed });
+    await lasagna2.initChannel("test:thing8", { jwt: jwtExplicitPassed });
     lasagna2.connect();
-    delete lasagna2.CHANNELS["unit-test:thing8"].params.jwt;
-    expect(await lasagna2.joinChannel("unit-test:thing8")).toBe(false);
+    delete lasagna2.CHANNELS["test:thing8"].params.jwt;
+    expect(await lasagna2.joinChannel("test:thing8")).toBe(false);
   });
 
   test("channelPush/3", () => {
-    lasagna.channelPush("unit-test:thing3", "new_sneech", { whatev: "a" });
+    lasagna.channelPush("test:thing3", "new_sneech", { whatev: "a" });
     expect(mockChannelPush).toHaveBeenCalledTimes(1);
     expect(mockChannelPush).toHaveBeenCalledWith("new_sneech", { whatev: "a" });
   });
 
   test("registerEventHandler/2", () => {
     const cb = () => "hola!";
-    lasagna.registerEventHandler("unit-test:thing3", "starred_sneech", cb);
+    lasagna.registerEventHandler("test:thing3", "starred_sneech", cb);
     expect(mockChannelOn).toHaveBeenCalledTimes(1);
     expect(mockChannelOn).toHaveBeenCalledWith("starred_sneech", cb);
   });
 
   test("leaveChannel/1", () => {
-    lasagna.leaveChannel("unit-test:thing3");
+    lasagna.leaveChannel("test:thing3");
     expect(mockChannelLeave).toHaveBeenCalledTimes(1);
-    expect(lasagna.CHANNELS["unit-test:thing3"]).toBeUndefined();
+    expect(lasagna.CHANNELS["test:thing3"]).toBeUndefined();
   });
 
   test("leaveAllChannels/0", () => {
     expect(Object.keys(lasagna.CHANNELS).length > 0);
     lasagna.leaveAllChannels();
     expect(lasagna.CHANNELS).toEqual({});
+  });
+
+  test("shouldAuth/1 true", () => {
+    expect(lasagna.shouldAuth("push:some:such")).toBe(true);
+    expect(lasagna.shouldAuth("push-presence:some:such")).toBe(true);
+    expect(lasagna.shouldAuth("bus:some:such")).toBe(true);
+    expect(lasagna.shouldAuth("weird:default:safe")).toBe(true);
+  });
+
+  test("shouldAuth/1 false", () => {
+    expect(lasagna.shouldAuth("push-no_auth:some:such")).toBe(false);
+    expect(lasagna.shouldAuth("push-no_auth-presence:some:such")).toBe(false);
+    expect(lasagna.shouldAuth("bus-no_auth:some:such")).toBe(false);
   });
 });


### PR DESCRIPTION
### Proposed Changes

- Switch `no_auth` topic prefix from `push:no_auth:whatever` to `push-no_auth:whatever` format. We've already done this on the server-side. This just brings the change into alignment.

### How To Test

Unit tests.