### PR TITLE
Hang rejoin behaviors on the correct events

### DIFF
--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -130,16 +130,6 @@ describe("Channel", () => {
     expect(await lasagna.joinChannel("test:thing1")).toBe(false);
   });
 
-  test("joinChannel/2 with non-string JWT fetch response", async () => {
-    // @ts-ignore we want this type mismatch for the test scenario
-    const lasagna2 = new Lasagna(() => Promise.resolve({ notajwt: 1 }), url);
-    await lasagna2.initSocket({ jwt: jwtExplicitPassed });
-    await lasagna2.initChannel("test:thing8", { jwt: jwtExplicitPassed });
-    lasagna2.connect();
-    delete lasagna2.CHANNELS["test:thing8"].params.jwt;
-    expect(await lasagna2.joinChannel("test:thing8")).toBe(false);
-  });
-
   test("channelPush/3", () => {
     lasagna.channelPush("test:thing3", "new_sneech", { whatev: "a" });
     expect(mockChannelPush).toHaveBeenCalledTimes(1);

--- a/test/mocks/phoenix.ts
+++ b/test/mocks/phoenix.ts
@@ -5,6 +5,7 @@ export const mockSocketOnOpen = jest.fn();
 export const mockSocketOnClose = jest.fn();
 export const mockSocketOnError = jest.fn();
 export const mockChannelOn = jest.fn();
+export const mockChannelOnClose = jest.fn();
 export const mockChannelOnError = jest.fn();
 export const mockChannelPush = jest.fn();
 export const mockChannelLeave = jest.fn();
@@ -13,13 +14,17 @@ export const mockChannelJoin = jest.fn().mockImplementation(() => {
 });
 
 const mockPush = jest.fn().mockImplementation(() => ({
-  receive: (_event: string, callback: () => any) => callback(),
+  receive: function (status: string, callback: () => any) {
+    callback();
+    return this;
+  },
 }));
 
 const mockChannel = jest.fn().mockImplementation(() => ({
   join: mockChannelJoin,
   leave: mockChannelLeave,
   on: mockChannelOn,
+  onClose: mockChannelOnClose,
   onError: mockChannelOnError,
   push: mockChannelPush,
 }));


### PR DESCRIPTION
We had been trying to manage our JWT rejoin behaviors using `onError` event handlers, but, the actual events we want are the `join` response and the `onClose` (clean) of the Channel handlers.
