### PR TITLE
Add async keyword back to joinChannel

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -141,7 +141,7 @@ export default class Lasagna {
     };
   }
 
-  joinChannel(topic: Topic, callback: Callback = () => undefined) {
+  async joinChannel(topic: Topic, callback: Callback = () => undefined) {
     if (typeof topic !== "string" || topic === "" || !this.CHANNELS[topic]) {
       return false;
     }


### PR DESCRIPTION
A little overzealous in removal. The receive call back can be async making this entire function something we want to wait for always.