### PR TITLE
Make a Node modules default export

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -243,3 +243,5 @@ export default class Lasagna {
     this.connect();
   };
 }
+
+module.exports = Lasagna;


### PR DESCRIPTION
So browser clients can use `Lasagna` and not `Lasagna.default`.