### PR TITLE
Attempt a rejoin if the param jwt given to initSocket is bad

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -55,10 +55,14 @@ export default class Lasagna {
    */
 
   async initSocket(params: Params = {}, callbacks?: SocketCbs) {
-    const jwt = params.jwt || (await this.#getJwt("socket", { params }));
+    let jwt = params.jwt;
 
     if (this.isInvalidJwt(jwt)) {
-      return false;
+      jwt = await this.#getJwt("socket", { params });
+
+      if (this.isInvalidJwt(jwt)) {
+        return false;
+      }
     }
 
     this.#socket = new Socket(this.#lasagnaUrl, { params: { jwt } });
@@ -115,7 +119,7 @@ export default class Lasagna {
       }
     }
 
-    const channel = this.#socket.channel(topic, params);
+    const channel = this.#socket.channel(topic, { jwt: params.jwt });
 
     if (callbacks && callbacks.onError) {
       channel.onError(callbacks.onError);

--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -43,16 +43,17 @@ describe("Socket", () => {
     expect(mockSocketConnect).toHaveBeenCalledTimes(1);
   });
 
-  test("initSocket/1 with bad jwt param", async () => {
-    // @ts-ignore: type mismatch
-    expect(await lasagna.initSocket({ jwt: [] })).toBe(false);
-    lasagna.connect();
-    expect(MockPhoenix.Socket).toHaveBeenCalledTimes(0);
-  });
-
   test("initSocket/1 with bad fetcher response", async () => {
     const burntLasagna = new Lasagna(() => Promise.resolve(""), url);
     expect(await burntLasagna.initSocket()).toBe(false);
+  });
+
+  test("initSocket/1 with bad jwt param and bad fetcher response", async () => {
+    const burntLasagna = new Lasagna(() => Promise.resolve(""), url);
+    // @ts-ignore: type mismatch
+    expect(await burntLasagna.initSocket({ jwt: [] })).toBe(false);
+    burntLasagna.connect();
+    expect(MockPhoenix.Socket).toHaveBeenCalledTimes(0);
   });
 
   test("initSocket/1 with jwt param and callbacks", async () => {


### PR DESCRIPTION
Previously, if explicitly given an invalid jwt during socket init, we didn't even try to get a new one. We just bailed out.

This change makes it where we detect an invalid jwt, try once to get a good one, _then_ bail if that fails.