### PR TITLE
Add event handler rebind functionality

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -21,7 +21,7 @@ type ChannelMap = { [topic: string]: ChannelHandle };
 type DecodedJWT = { cxp?: number; exp: number; iat: number; iss: string };
 type Event = string;
 type EventBindingsMap = {
-  [event: string]: Array<Callback>;
+  [event: string]: Callback[];
 };
 type GetJwtFn = (
   type: "socket" | "channel",
@@ -154,8 +154,8 @@ export default class Lasagna {
       channel.onClose(callbacks.onClose);
     }
 
-    eventBindings["banned"] = [() => this.leaveChannel(topic)];
-    eventBindings["kicked"] = [() => this.#emitChannelRejoin(topic)];
+    eventBindings.banned = [() => this.leaveChannel(topic)];
+    eventBindings.kicked = [() => this.#emitChannelRejoin(topic)];
 
     this.CHANNELS[topic] = {
       callbacks,

--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -264,11 +264,17 @@ export default class Lasagna {
   };
 
   #bulkBindEvents = (topic: Topic, eventBindings: EventBindingsMap) => {
-    Object.entries(eventBindings).forEach(([event, callbacks]) =>
+    if (!this.CHANNELS[topic] || !this.CHANNELS[topic].channel) {
+      return false;
+    }
+
+    Object.entries(eventBindings).forEach(([event, callbacks]) => {
+      this.CHANNELS[topic].channel.off(event);
+
       callbacks.forEach((callback) =>
         this.CHANNELS[topic].channel.on(event, callback)
-      )
-    );
+      );
+    });
   };
 
   #emitChannelRejoin = (topic: Topic) => {

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -35,7 +35,7 @@ describe("Channel", () => {
     jest.clearAllMocks();
   });
 
-  test("initChannel/2 without jwt param", async () => {
+  test("initChannel/4 without jwt param", async () => {
     await lasagna.initChannel("test:thing2", { private: "thingy" });
     const handle = lasagna.CHANNELS["test:thing2"];
 
@@ -48,7 +48,7 @@ describe("Channel", () => {
     expect(handle.eventBindings).toHaveProperty("kicked");
   });
 
-  test("initChannel/2 with jwt param", async () => {
+  test("initChannel/4 with jwt param", async () => {
     await lasagna.initChannel("test:thing2", { jwt: jwtExplicitPassed });
 
     expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
@@ -58,7 +58,7 @@ describe("Channel", () => {
     });
   });
 
-  test("initChannel/2 with expired jwt param", async () => {
+  test("initChannel/4 with expired jwt param", async () => {
     await lasagna.initChannel("test:thing2", { jwt: jwtExpired });
 
     expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
@@ -68,7 +68,7 @@ describe("Channel", () => {
     });
   });
 
-  test("initChannel/2 with malformed jwt param", async () => {
+  test("initChannel/4 with malformed jwt param", async () => {
     await lasagna.initChannel("test:thing2", { jwt: "blahblah" });
 
     expect(lasagna.CHANNELS["test:thing2"].channel).toBeDefined();
@@ -78,12 +78,12 @@ describe("Channel", () => {
     });
   });
 
-  test("initChannel/2 with no socket", async () => {
+  test("initChannel/4 with no socket", async () => {
     const burntLasagna = new Lasagna(() => Promise.resolve("whatever"), url);
     expect(await burntLasagna.initChannel("test:thing5")).toBe(false);
   });
 
-  test("initChannel/2 with non-string JWT fetch response", async () => {
+  test("initChannel/4 with non-string JWT fetch response", async () => {
     // @ts-ignore we want this type mismatch for the test scenario
     const lasagna2 = new Lasagna(() => Promise.resolve({ notajwt: 1 }), url);
     await lasagna2.initSocket({ jwt: jwtExplicitPassed });
@@ -171,12 +171,12 @@ describe("Channel", () => {
     lasagna.unregisterAllEventHandlers("test:thing3", "unstarred_sneech");
     expect(mockChannelOff).toHaveBeenCalledTimes(1);
     expect(mockChannelOff).toHaveBeenCalledWith("unstarred_sneech");
-    expect(lasagna.CHANNELS["test:thing3"].eventBindings).toMatchObject({
-      starred_sneech: [cb],
-    });
     expect(lasagna.CHANNELS["test:thing3"].eventBindings).not.toHaveProperty(
       "unstarred_sneech"
     );
+    expect(lasagna.CHANNELS["test:thing3"].eventBindings).toMatchObject({
+      starred_sneech: [cb],
+    });
   });
 
   test("leaveChannel/1", () => {

--- a/test/mocks/phoenix.ts
+++ b/test/mocks/phoenix.ts
@@ -11,6 +11,7 @@ export const mockSocketOnError = jest.fn();
 export const mockChannelOn = jest.fn();
 export const mockChannelOnClose = jest.fn();
 export const mockChannelOnError = jest.fn();
+export const mockChannelOff = jest.fn();
 export const mockChannelPush = jest.fn();
 export const mockChannelLeave = jest.fn();
 export const mockChannelJoin = jest.fn().mockImplementation(() => {
@@ -34,6 +35,7 @@ const mockChannel = jest.fn().mockImplementation(() => ({
   on: mockChannelOn,
   onClose: mockChannelOnClose,
   onError: mockChannelOnError,
+  off: mockChannelOff,
   push: mockChannelPush,
 }));
 


### PR DESCRIPTION
`phoenix.js`'s channel API is "immutable-ish".  For example, you cannot explicitly rejoin a channel after a channel has been joined once before.

We wrap `phoenix.js` with Lasagna-specific logic to manage our auth concerns and other such feature needs. One thing we've overlooked to date is client usage of custom events.

**Existing flow:**

1. Client is instantiated in a piece of software.
2. Custom events are bound to channel(s) via `on`.
3. We refresh JWTs or handle a `cxp` and reinit the channel.
4. BROKEN. A whole new channel is created -- _without_ the original `on` bindings.

**What we want:**

1. Client is instantiated in a piece of software.
2. Custom events are bound to channel(s) via `on`.
3. We refresh JWTs or handle a `cxp` and reinit the channel.
4. A whole new channel is created -- automatically rebinding the original `on` handlers.
 
Fixes #43.