### PR TITLE
Remove superfluous channel user_agent meta

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -141,10 +141,7 @@ export default class Lasagna {
       }
     }
 
-    const channel = this.#socket.channel(topic, {
-      jwt: params.jwt,
-      user_agent: LASAGNA_JS_UA,
-    });
+    const channel = this.#socket.channel(topic, { jwt: params.jwt });
 
     if (callbacks.onError) {
       channel.onError(callbacks.onError);


### PR DESCRIPTION
We don't need or want it. On the service side, we just use the meta sent on socket connect.