### PR TITLE
Add unregister event handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 coverage
 dist
 node_modules
+.idea

--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -276,7 +276,7 @@ export default class Lasagna {
   }
 
   unregisterEventHandler(topic: Topic, event: Event, callback: Callback, eventListenerRef: number) {
-    if (!this.CHANNELS[topic] || !callback || !eventListenerRef) {
+    if (!this.CHANNELS[topic] || !callback || Number.isNaN(eventListenerRef)) {
       return false;
     }
 

--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -275,6 +275,18 @@ export default class Lasagna {
     return this.CHANNELS[topic].channel.on(event, callback);
   }
 
+  unregisterEventHandler(topic: Topic, event: Event, callback: Callback, eventListenerRef: number) {
+    if (!this.CHANNELS[topic]) {
+      return false;
+    }
+
+    this.CHANNELS[topic].channel.off(event, eventListenerRef);
+
+    this.CHANNELS[topic].eventBindings[event] = this.CHANNELS[topic].eventBindings[event].filter(
+        ( eventBinding ) => eventBinding !== callback
+    );
+  }
+
   unregisterAllEventHandlers(topic: Topic, event: Event) {
     if (!this.CHANNELS[topic]) {
       return false;

--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -276,7 +276,7 @@ export default class Lasagna {
   }
 
   unregisterEventHandler(topic: Topic, event: Event, callback: Callback, eventListenerRef: number) {
-    if (!this.CHANNELS[topic] || !callback || Number.isNaN(eventListenerRef)) {
+    if (!this.CHANNELS[topic] || !callback || typeof eventListenerRef !== 'number') {
       return false;
     }
 

--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -276,7 +276,7 @@ export default class Lasagna {
   }
 
   unregisterEventHandler(topic: Topic, event: Event, callback: Callback, eventListenerRef: number) {
-    if (!this.CHANNELS[topic]) {
+    if (!this.CHANNELS[topic] || !callback || !eventListenerRef) {
       return false;
     }
 

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -151,6 +151,30 @@ describe("Channel", () => {
     });
   });
 
+  test("unregisterEventHandler/4", () => {
+    const cb = () => "hola!";
+    let ref = lasagna.registerEventHandler("test:thing3", "starred_sneech", cb);
+
+    expect(mockChannelOn).toHaveBeenCalledTimes(1);
+    expect(mockChannelOn).toHaveBeenCalledWith("starred_sneech", cb);
+    expect(lasagna.CHANNELS["test:thing3"].eventBindings).toMatchObject({
+      starred_sneech: [cb],
+    });
+
+    // To make lint happy.
+    if (!ref) {
+      ref = 0;
+    }
+
+    lasagna.unregisterEventHandler("test:thing3", "starred_sneech", cb, ref);
+
+    expect(mockChannelOff).toHaveBeenCalledTimes(1);
+    expect(mockChannelOff).toHaveBeenCalledWith("starred_sneech", ref);
+    expect(lasagna.CHANNELS["test:thing3"].eventBindings).toMatchObject({
+      starred_sneech: [],
+    });
+  });
+
   test("unregisterAllEventHandlers/2", () => {
     const cb = () => "hola!";
     const cb2 = () => "hola2!";


### PR DESCRIPTION
In this PR, we add a new method called `unregisterEventHandler` to remove a previously added event handler and its callback. We already have `unregisterAllEventHandlers` but sometimes we need to unregister just one.

@mirka @hewsut I checked [the documentation](https://hexdocs.pm/phoenix/js/) for Phoenix's `channel.off` and it requires the reference to the previously called `channel.on`. It would be great if we could just pass the same callback by object reference to accomplish this but it looks like Phoenix doesn't support it.

## Testing instructions

Run the tests with `npm run test`. Code review.