### PR TITLE
On error only fetch a new JWT, let Phoenix do the reconnection

### DIFF
--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -80,7 +80,8 @@ export default class Lasagna {
    */
 
   async initSocket(params: Params = {}, callbacks?: SocketCbs) {
-    let { jwt, ...jwtParams } = params;
+    const { jwt: initialJwt, ...jwtParams } = params;
+    let jwt = initialJwt;
     let jwtRequest: Promise<string> | null = null;
 
     if (this.isInvalidJwt(jwt)) {

--- a/lib/lasagna.ts
+++ b/lib/lasagna.ts
@@ -80,10 +80,11 @@ export default class Lasagna {
    */
 
   async initSocket(params: Params = {}, callbacks?: SocketCbs) {
-    let jwt = params.jwt;
+    let { jwt, ...jwtParams } = params;
+    let jwtRequest: Promise<string> | null = null;
 
     if (this.isInvalidJwt(jwt)) {
-      jwt = await this.#safeGetJwt("socket", { params });
+      jwt = await this.#safeGetJwt("socket", { params: jwtParams });
 
       if (this.isInvalidJwt(jwt)) {
         this.disconnect();
@@ -92,7 +93,7 @@ export default class Lasagna {
     }
 
     this.#socket = new Socket(this.#lasagnaUrl, {
-      params: { jwt, user_agent: LASAGNA_JS_UA },
+      params: () => ({ jwt, user_agent: LASAGNA_JS_UA }),
     });
 
     if (callbacks && callbacks.onOpen) {
@@ -103,13 +104,21 @@ export default class Lasagna {
       this.#socket.onClose(callbacks.onClose);
     }
 
-    this.#socket.onError(() => {
+    this.#socket.onError(async () => {
       if (callbacks && callbacks.onError) {
         callbacks.onError();
       }
 
       if (this.isInvalidJwt(jwt)) {
-        this.#reconnectSocket(params, callbacks);
+        // Refresh the token so that Phoenix `reconnectTimer` can pick it up on next try
+        if (!jwtRequest) {
+          jwtRequest = this.#safeGetJwt("socket", { params: jwtParams });
+        }
+        jwt = await jwtRequest;
+        jwtRequest = null;
+        if (this.isInvalidJwt(jwt)) {
+          this.disconnect();
+        }
       }
     });
   }
@@ -376,13 +385,6 @@ export default class Lasagna {
     }
 
     this.joinChannel(topic, onJoinCb);
-  };
-
-  #reconnectSocket = async (params: Params, callbacks?: SocketCbs) => {
-    this.disconnect();
-    delete params.jwt;
-    await this.initSocket(params, callbacks);
-    this.connect();
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/lasagna",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "lasagna.js, the reference client for the Lasagna web service",
   "main": "dist/lasagna.js",
   "types": "dist/lasagna.d.ts",

--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -31,9 +31,8 @@ describe("Socket", () => {
   test("initSocket/1 without jwt param", async () => {
     await lasagna.initSocket({ user_id: "dmte", email: "bob@example.com" });
     lasagna.connect();
-    expect(MockPhoenix.Socket).toHaveBeenCalledWith(url, {
-      params: expect.objectContaining({ jwt }),
-    });
+    expect(MockPhoenix.Socket.mock.calls[0][0]).toBe(url);
+    expect(MockPhoenix.Socket.mock.calls[0][1].params()).toMatchObject({ jwt });
     expect(mockSocketConnect).toHaveBeenCalledTimes(1);
   });
 
@@ -41,9 +40,8 @@ describe("Socket", () => {
     const params = { jwt: anotherJwt };
     await lasagna.initSocket(params);
     lasagna.connect();
-    expect(MockPhoenix.Socket).toHaveBeenCalledWith(url, {
-      params: expect.objectContaining({ jwt: anotherJwt }),
-    });
+    expect(MockPhoenix.Socket.mock.calls[0][0]).toBe(url);
+    expect(MockPhoenix.Socket.mock.calls[0][1].params()).toMatchObject({ jwt: anotherJwt });
     expect(mockSocketConnect).toHaveBeenCalledTimes(1);
   });
 
@@ -69,9 +67,8 @@ describe("Socket", () => {
     };
     await lasagna.initSocket(params, callbacks);
     lasagna.connect();
-    expect(MockPhoenix.Socket).toHaveBeenCalledWith(url, {
-      params: expect.objectContaining({ jwt: anotherJwt }),
-    });
+    expect(MockPhoenix.Socket.mock.calls[0][0]).toBe(url);
+    expect(MockPhoenix.Socket.mock.calls[0][1].params()).toMatchObject({ jwt: anotherJwt });
     expect(mockSocketOnOpen).toHaveBeenCalledTimes(1);
     expect(mockSocketOnOpen).toHaveBeenCalledWith(callbacks.onOpen);
     expect(mockSocketOnClose).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixes #182. When the websocket fires an `error` event, we don't reconnect, but only fetch the new JWT token if it's expired. The reconnection will be handled by Phoenix internally. If the JWT is expired, a few reconnections will still fail until the REST response with the new token arrives and the token is stored in a `jwt` variable.

The `params` object that contains the `jwt` field is being modified to a callback, so that the latest value of `jwt` is always used.

I believe that the infinite loop was caused by both Phoenix and Lasagna trying to furiously reconnect and fetch the token on each `error` event.

**How to test:**
That will be a long journey. Update the `lasagna` package in the P2 project, rebuild it, deploy to wpcom and then test that a P2 page still has working Lasagna client and that it reconnects on error.